### PR TITLE
商品一覧表示機能#6

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,12 +127,13 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
+    <% if @items.any? %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+     <% @items.each do |item| %> 
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,10 +144,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,8 +156,9 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+    <% else %>
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
@@ -178,6 +180,7 @@
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,12 +128,12 @@
     </div>
     <ul class='item-lists'>
     <% if @items.any? %>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
      <% @items.each do |item| %> 
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -157,10 +157,10 @@
         <% end %>
       </li>
     <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
     <% else %>
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      
+      
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -178,8 +178,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      
+     
     <% end %>
     </ul>
   </div>


### PR DESCRIPTION
## What
- 商品一覧表示機能を実装
- 出品された商品を「画像・商品名・価格・配送料の負担」の情報とともに一覧表示
- 出品日時が新しい順に表示されるように実装
- 商品が存在しない場合にダミー商品を表示する条件分岐を実装

## Why
商品一覧表示機能はFURIMAにおいてユーザーが商品を閲覧・比較するための基盤となる機能であるため実装した。
また、新着順で表示することで最新の商品を優先的に確認でき、ユーザーの購買行動を促進することを目的としている。
さらに、商品が存在しない場合でもダミー表示を行うことで、画面の意図をユーザーに伝え、UXの低下を防ぐため。

## Gyazo
- 商品のデータがない場合は、ダミー商品が表示されている動画
https://i.gyazo.com/adb34fac99e3ae96cd93bb456397eb89.gif
- 商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです） 
https://i.gyazo.com/5a6d9901b13b3e6a628acc8696e6f13b.gif
