### PR TITLE
商品削除機能#9

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order('created_at DESC')
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
   <% if current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
 
   <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root "items#index"
-  resources :items, only: [:new, :create, :show, :edit, :update]
+  resources :items, only: [:new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
## What
- 商品削除機能を実装
- ログイン状態かつ出品者本人の場合のみ削除できるよう制御を実装
- ログイン状態であっても、他ユーザーの出品商品は削除できないようコントローラーとビューの両方で制御

## Why
商品削除機能は、ユーザーが不要となった商品情報を削除するために必要な機能である。 また、ログイン状態およびユーザーの権限に応じて画面とコントローラーの双方で制御を行うことで、不正な操作を防止し、適切なアクセス制御を実現するため。

## Gyazo
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画 https://i.gyazo.com/d1e827d1379f1eec159d53d4cba1b602.gif